### PR TITLE
Created Additional Google Project Input Form, Resolved Conflicts, and Resolved Prop Issue

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -18,6 +18,7 @@ class App extends React.Component {
       // google
       googleKey: '',
       runtime: undefined,
+      googleProject: '',
       // aws
       awsAccessKey: '',
       awsSecretAccessKey: '',
@@ -230,6 +231,7 @@ class App extends React.Component {
     if (this.state.pageSelect === 'Gcloud') {
       displayed = <GoogleFunctionForm
         submitKey={this.handleSubmitKey}
+        googleProject={this.googleProject}
         runtime={this.state.runtime}
         functionName={this.state.functionName}
         googleKey={this.state.googleKey}

--- a/client/components/GoogleFunctionForm.jsx
+++ b/client/components/GoogleFunctionForm.jsx
@@ -6,7 +6,9 @@ const GoogleFunctionForm = (props) => {
     return (
       <React.Fragment>
           <h2>GCloud</h2>
-        <input name="functionName" onChange={(e) => props.updateInfo(e.target.name, e.target.value)} type="text" name="functionName" placeholder="Function Name" />
+          <div className="googleInfo">
+          <input id="googleProject" name="googleProject" onChange={(e) => props.updateInfo(e.target.name, e.target.value)} type="text" placeholder="Project Name" />
+        <input name="functionName" onChange={(e) => props.updateInfo(e.target.name, e.target.value)} type="text" placeholder="Function Name" />
         <select onChange={(e) => props.updateInfo('runtime', e.target.value)}>
           <option value='1'>Runtime</option>
           <option value="nodejs8">Node 8</option>
@@ -15,12 +17,13 @@ const GoogleFunctionForm = (props) => {
           <option value="go111">Go 1.11</option>
           <option value="go113">Go 1.13</option>
         </select>
+          </div>
         <pre>
           <textarea name="googleKey" onChange={(e) => props.updateInfo(e.target.name, e.target.value)} placeholder="gcloud auth key" rows="10"></textarea>
         </pre>
         <button onClick={ () => props.submitKey('googleKey') }>Save key</button>
           <MyDropzone uploadedFunction={props.uploadedFunction} updateInfo={props.updateInfo} />
-        <button onClick={() => axios.post('/gcloud/deploy', {functionName: props.functionName, runtime: props.runtime, fn: props.code})
+        <button onClick={() => axios.post('/gcloud/deploy', {project: props.googleProject, fn_name: props.functionName, runtime: props.runtime, fn: props.uploadedFunction})
             .then(response => console.log('successfully deployed'))}
 
         >Deploy</button>

--- a/client/stylesheets/style.scss
+++ b/client/stylesheets/style.scss
@@ -141,3 +141,12 @@ img {
   height: 25px;
   width: 25px;
 }
+
+.googleInfo {
+  display: flex;
+  justify-content: space-around;
+}
+
+#googleProject {
+  margin-right: 5px;
+}


### PR DESCRIPTION
GCloud requires an additional piece of information in order to successfully deploy microservices. This information is the pre-existing Project Name that exists in GCloud. An appropriate property was created in state, and the prop was drilled down to GoogleFunctionForm wherein the Deploy button now sends this information along with the other information in the body of the POST request.

Several merge conflicts were resolved due to the introduction of the contentious GoogleCredentialsComponent.

After renaming several properties in state to better reflect their purpose, multiple props were affected in child components. These issues have been resolved.